### PR TITLE
Full support of hidden files

### DIFF
--- a/hdfscm/utils.py
+++ b/hdfscm/utils.py
@@ -46,7 +46,7 @@ def to_fs_path(path, root):
 
 def is_hidden(fs_path, root):
     path = to_api_path(fs_path, root)
-    return any(part.startswith('.') for part in path.split("/"))
+    return any(part.startswith('.') or part.startswith('_') for part in path.split("/"))
 
 
 @contextmanager


### PR DESCRIPTION
Although original `hdfscm` supports `allow_hidden` property
```python
allow_hidden = Bool(False, config=True, help="Allow access to hidden files")
```
... it does not show hidden files in case this property is set to `True`.

This pull request adds the following changes
- allows to see hidden files in the directory structure in case `allow_hidden=True`
- treats all the files which start not only with `.`, but also with `_` to be the hidden ones as [hdfs does](https://github.com/apache/hadoop/blob/c613296dc85ac7b22c171c84f578106b315cc012/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/FileInputFormat.java#L96)